### PR TITLE
Fix: Implement automatic token refresh on expiry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -432,6 +432,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -521,6 +522,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -572,6 +574,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -627,6 +630,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -675,6 +679,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -723,6 +728,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -768,6 +774,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -806,6 +813,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -836,6 +844,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -866,6 +875,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -965,6 +975,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1004,6 +1015,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1066,6 +1078,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1118,6 +1131,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1177,6 +1191,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1227,6 +1242,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1286,6 +1302,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1313,6 +1330,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1345,6 +1363,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1376,6 +1395,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1436,6 +1456,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={false}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1477,6 +1498,7 @@ function App() {
                   requiresAuth={false}
                   dynamicEmailDefault={userEmail}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1528,6 +1550,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 
@@ -1601,6 +1624,7 @@ function App() {
                   setProfile={setProfile}
                   requiresAuth={true}
                   defaultStatus={200}
+                  refreshToken={generateAndSetCustomToken}
                 />
               )}
 


### PR DESCRIPTION
The application was previously sending the same authentication token repeatedly, leading to 403 errors when the token expired.

This commit introduces an automatic token refresh mechanism:

1.  `ApiEndpointDoc.tsx` now detects 401/403 errors with code 700 (indicating an invalid/expired token).
2.  Upon such an error, it calls a `refreshToken` function, which is `generateAndSetCustomToken` from `App.tsx`.
3.  `generateAndSetCustomToken` fetches a new Magic Link DID token and requests a new application token from the `/api/token/generate` endpoint.
4.  The new token is stored in localStorage and, crucially, updated in the browser cookies.
5.  `ApiEndpointDoc.tsx` then automatically retries the original failed API request once with the new token.

This ensures that if a token expires during your session, it is seamlessly refreshed, and your experience is not interrupted by authentication errors.